### PR TITLE
Add user and group synchronization to Humanitec integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This integration syncs the following Humanitec entities to Port:
 - **Deployment Sets** - Deployment configurations
 - **Pipelines** - CI/CD pipeline definitions
 - **Deployment Deltas** - Deployment change definitions
+- **Users** - Organization users and their roles
+- **Groups** - User groups and permissions
 
 ## Prerequisites
 

--- a/integration/clients/humanitec_client.py
+++ b/integration/clients/humanitec_client.py
@@ -263,7 +263,6 @@ class HumanitecClient:
             "GET", endpoint, headers=humanitec_headers
         )
         
-        # Separate users and groups using a single loop
         users = []
         groups = []
         for entity in all_entities:

--- a/integration/clients/humanitec_client.py
+++ b/integration/clients/humanitec_client.py
@@ -263,9 +263,14 @@ class HumanitecClient:
             "GET", endpoint, headers=humanitec_headers
         )
         
-        # Separate users and groups based on type
-        users = [entity for entity in all_entities if entity.get("type") == "user"]
-        groups = [entity for entity in all_entities if entity.get("type") == "group"]
+        # Separate users and groups using a single loop
+        users = []
+        groups = []
+        for entity in all_entities:
+            if entity.get("type") == "user":
+                users.append(entity)
+            elif entity.get("type") == "group":
+                groups.append(entity)
         
         logger.info(f"Received {len(users)} users and {len(groups)} groups from Humanitec")
         return users, groups

--- a/integration/clients/humanitec_client.py
+++ b/integration/clients/humanitec_client.py
@@ -254,3 +254,18 @@ class HumanitecClient:
         )
         logger.info(f"Received {len(deployment_deltas)} deployment deltas for {app['id']}")
         return deployment_deltas
+
+    async def get_users_and_groups(self) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        """Get all users and groups in the organization from a single API call."""
+        endpoint = "users"
+        humanitec_headers = self.get_humanitec_headers()
+        all_entities: List[Dict[str, Any]] = await self.send_api_request(
+            "GET", endpoint, headers=humanitec_headers
+        )
+        
+        # Separate users and groups based on type
+        users = [entity for entity in all_entities if entity.get("type") == "user"]
+        groups = [entity for entity in all_entities if entity.get("type") == "group"]
+        
+        logger.info(f"Received {len(users)} users and {len(groups)} groups from Humanitec")
+        return users, groups

--- a/integration/clients/humanitec_client.py
+++ b/integration/clients/humanitec_client.py
@@ -273,3 +273,13 @@ class HumanitecClient:
         
         logger.info(f"Received {len(users)} users and {len(groups)} groups from Humanitec")
         return users, groups
+
+    async def get_users_in_group(self, group_id: str) -> List[Dict[str, Any]]:
+        """Get all users in a specific group."""
+        endpoint = f"groups/{group_id}/users"
+        humanitec_headers = self.get_humanitec_headers()
+        users: List[Dict[str, Any]] = await self.send_api_request(
+            "GET", endpoint, headers=humanitec_headers
+        )
+        logger.info(f"Received {len(users)} users in group {group_id}")
+        return users

--- a/integration/main.py
+++ b/integration/main.py
@@ -561,7 +561,6 @@ class HumanitecExporter:
     async def sync_users_and_groups(self) -> None:
         logger.info(f"Syncing entities for blueprints {BLUEPRINT.USER} and {BLUEPRINT.GROUP}")
         
-        # Single API call to get all users and groups
         users, groups = await self.humanitec_client.get_users_and_groups()
 
         def create_user_entity(user):
@@ -589,7 +588,6 @@ class HumanitecExporter:
                 "relations": {},
             }
 
-        # Create tasks for both users and groups
         user_tasks = [
             self.port_client.upsert_entity(
                 blueprint_id=BLUEPRINT.USER,
@@ -606,7 +604,6 @@ class HumanitecExporter:
             for group in groups
         ]
 
-        # Execute all tasks together
         await asyncio.gather(*(user_tasks + group_tasks))
         logger.info(f"Finished syncing {len(users)} users and {len(groups)} groups")
 

--- a/integration/main.py
+++ b/integration/main.py
@@ -23,6 +23,8 @@ class BLUEPRINT:
     DEPLOYMENT_SET = "humanitecDeploymentSet"
     PIPELINE = "humanitecPipeline"
     DEPLOYMENT_DELTA = "humanitecDeploymentDelta"
+    USER = "humanitecUser"
+    GROUP = "humanitecGroup"
 
 
 class HumanitecExporter:
@@ -556,6 +558,59 @@ class HumanitecExporter:
         await asyncio.gather(*tasks)
         logger.info(f"Finished syncing entities for blueprint {BLUEPRINT.DEPLOYMENT_DELTA}")
 
+    async def sync_users_and_groups(self) -> None:
+        logger.info(f"Syncing entities for blueprints {BLUEPRINT.USER} and {BLUEPRINT.GROUP}")
+        
+        # Single API call to get all users and groups
+        users, groups = await self.humanitec_client.get_users_and_groups()
+
+        def create_user_entity(user):
+            return {
+                "identifier": user["id"],
+                "title": user["name"],
+                "properties": {
+                    "email": user.get("email"),
+                    "role": user.get("role"),
+                    "invite": user.get("invite"),
+                    "createdAt": user.get("created_at"),
+                },
+                "relations": {},
+            }
+
+        def create_group_entity(group):
+            return {
+                "identifier": group["id"],
+                "title": group["name"],
+                "properties": {
+                    "role": group.get("role"),
+                    "idp_id": group.get("idp_id"),
+                    "createdAt": group.get("created_at"),
+                },
+                "relations": {},
+            }
+
+        # Create tasks for both users and groups
+        user_tasks = [
+            self.port_client.upsert_entity(
+                blueprint_id=BLUEPRINT.USER,
+                entity_object=create_user_entity(user),
+            )
+            for user in users
+        ]
+
+        group_tasks = [
+            self.port_client.upsert_entity(
+                blueprint_id=BLUEPRINT.GROUP,
+                entity_object=create_group_entity(group),
+            )
+            for group in groups
+        ]
+
+        # Execute all tasks together
+        await asyncio.gather(*(user_tasks + group_tasks))
+        logger.info(f"Finished syncing {len(users)} users and {len(groups)} groups")
+
+
     async def sync_all(self) -> None:
         await self.sync_applications()
         await self.sync_environments()
@@ -568,6 +623,7 @@ class HumanitecExporter:
         await self.sync_deployment_sets()
         await self.sync_pipelines()
         await self.sync_deployment_deltas()
+        await self.sync_users_and_groups()
         logger.info("Event Finished")
 
     async def __call__(self, args) -> None:

--- a/resources/blueprints.json
+++ b/resources/blueprints.json
@@ -602,7 +602,14 @@
     "mirrorProperties": {},
     "calculationProperties": {},
     "aggregationProperties": {},
-    "relations": {}
+    "relations": {
+      "humanitecGroup": {
+        "title": "Groups",
+        "target": "humanitecGroup",
+        "required": false,
+        "many": true
+      }
+    }
   },
   {
     "identifier": "humanitecGroup",
@@ -618,7 +625,7 @@
         },
         "idp_id": {
           "title": "IDP ID",
-          "description": "The ID of the group in the identity provider",
+          "description": "The identity provider ID",
           "type": "string",
           "icon": "DefaultProperty"
         },

--- a/resources/blueprints.json
+++ b/resources/blueprints.json
@@ -563,5 +563,78 @@
         "many": false
       }
     }
+  },
+  {
+    "identifier": "humanitecUser",
+    "title": "Humanitec User",
+    "icon": "User",
+    "schema": {
+      "properties": {
+        "email": {
+          "title": "Email",
+          "description": "The email address of the user",
+          "type": "string",
+          "icon": "User",
+          "format": "user"
+        },
+        "role": {
+          "title": "Role",
+          "description": "The role of the user in the organization",
+          "type": "string",
+          "icon": "Role"
+        },
+        "invite": {
+          "title": "Invite Status",
+          "description": "The status of the user's invitation",
+          "type": "string",
+          "icon": "DefaultProperty"
+        },
+        "createdAt": {
+          "title": "Created At",
+          "description": "The date and time when the user was created",
+          "type": "string",
+          "format": "date-time",
+          "icon": "DefaultProperty"
+        }
+      },
+      "required": []
+    },
+    "mirrorProperties": {},
+    "calculationProperties": {},
+    "aggregationProperties": {},
+    "relations": {}
+  },
+  {
+    "identifier": "humanitecGroup",
+    "title": "Humanitec Group",
+    "icon": "TwoUsers",
+    "schema": {
+      "properties": {
+        "role": {
+          "title": "Role",
+          "description": "The role of the group in the organization",
+          "type": "string",
+          "icon": "Role"
+        },
+        "idp_id": {
+          "title": "IDP ID",
+          "description": "The ID of the group in the identity provider",
+          "type": "string",
+          "icon": "DefaultProperty"
+        },
+        "createdAt": {
+          "title": "Created At",
+          "description": "The date and time when the group was created",
+          "type": "string",
+          "format": "date-time",
+          "icon": "DefaultProperty"
+        }
+      },
+      "required": []
+    },
+    "mirrorProperties": {},
+    "calculationProperties": {},
+    "aggregationProperties": {},
+    "relations": {}
   }
 ]


### PR DESCRIPTION
- Updated README.md to include Users and Groups in the integration overview.
- Enhanced main.py with a new sync_users_and_groups method to fetch and sync users and groups.
- Added get_users_and_groups method in HumanitecClient to retrieve users and groups in a single API call.
- Updated blueprints.json to define schemas for Humanitec User and Group entities.